### PR TITLE
fix physics-graphics syncronization

### DIFF
--- a/pong.py
+++ b/pong.py
@@ -33,11 +33,7 @@ score = 0
 
 #draws the paddle. Also restricts its movement between the edges
 #of the window.
-def drawrect(screen,x,y):
-    if x <= 0:
-        x = 0
-    if x >= 699:
-        x = 699    
+def drawrect(screen,x,y):   
     pygame.draw.rect(screen,RED,[x,y,100,20])
      
 
@@ -81,7 +77,11 @@ while not done:
     screen.fill(BLACK)
     rect_x += rect_change_x
     rect_y += rect_change_y
-    
+    if rect_x <= 0:
+        rect_x = 0
+    if rect_x >= 699:
+        rect_x = 699 
+        
     ball_x += ball_change_x
     ball_y += ball_change_y
     


### PR DESCRIPTION
the `drawrect` function draws the paddle at x=0 if x<0; this leads to the paddle getting out of the window physically, whereas the graphical window shows it inside the window. so that if you then press the right arrow, you get a delay in paddle movement ( you wait till x > 0). If we don't allow the physical paddle to get out of the window, problem solved!